### PR TITLE
Start line shouldn't be null

### DIFF
--- a/lib/credo_sonarqube/formatter/sonarqube.ex
+++ b/lib/credo_sonarqube/formatter/sonarqube.ex
@@ -40,7 +40,7 @@ defmodule CredoSonarqube.Formatter.Sonarqube do
         "message" => message,
         "filePath" => base_folder <> to_string(filename),
         # Credo do not provide enough information for extended textRange
-        "textRange" => %{"startLine" => start_line}
+        "textRange" => %{"startLine" => start_line || 1}
       }
     }
   end


### PR DESCRIPTION
As SonarQube docs states, `startLine` field is an Integer `1-indexed`.
And sometimes credo can return nil value. (e.g. if test file is named `.ex` instead of `.exs`) which then breaks SQ.<br> [Here](https://docs.sonarqube.org/latest/analysis/generic-issue/#header-1) 